### PR TITLE
Update _index.md

### DIFF
--- a/content/footer/_index.md
+++ b/content/footer/_index.md
@@ -18,7 +18,7 @@ extra:
 
 ###### [Buy the Token](https://library.threefold.me/info/threefold#/tokens/threefold__how_to_buy)
 
-<h6><a href="" onclick="window.location.href='/farm'">Start Farming</a></h6>
+###### [Start Farming](https://manual.grid.tf/farmers/farmers.html)
 
 ###### [Farming Community](https://t.me/threefoldfarmers)
 


### PR DESCRIPTION
"Start Farming" is directing to the existing URL: https://manual.grid.tf/TF_Farmer_Guide/tf_farmer_guide_readme.html. I believe it needs to redirect to https://manual.grid.tf/farmers/farmers.html.