### PR TITLE
build, removed repetitive content

### DIFF
--- a/content/build/index.md
+++ b/content/build/index.md
@@ -55,19 +55,3 @@ Private overlay networks and global end-to-end encryption minimize attack surfac
 ## A Global **Edge Infrastructure**
 
 {% end %}
-
-<!-- section 6 -->
-
-{% row(style="center margin narrow") %}
-
-## Learn **More**
-
-Dive into more resources and join the open-source movement building a better digital future.
-
-<br>
-
-<button>[For Developers](https://manual.grid.tf/developers/developers.html)</button>
-<button>[For Sysadmins](https://manual.grid.tf/system_administrators/system_administrators.html)</button>
-<button>[Grid Chat](https://t.me/threefoldtesting)</button>
-
-{% end %}


### PR DESCRIPTION
Currently, the sub-sections in the section build (https://www.threefold.io/build/):

* build the future
* learn more

have the same buttons and links. This might be repetitive.

I simply removed the repetition.

Note: I don't have access to the repo itself, so I did a fork.