### PR TITLE
Add standby nodes to stats counts

### DIFF
--- a/templates/shortcodes/cloud_stats.html
+++ b/templates/shortcodes/cloud_stats.html
@@ -1,12 +1,15 @@
-{% set data = load_data(url="https://gridproxy.grid.tf/stats?status=up", required=false, format="json") %}
-{% if data %}
-  {% set capacity = (data.totalHru + data.totalSru) / 1024 / 1024 / 1024 / 1024 / 1024 %}
-  {% set nodes = data.nodes %}
-  {% set countries = data.countries %}
-  {% set cores = data.totalCru %}
+{% set online = load_data(url="https://gridproxy.grid.tf/stats?status=up", required=false, format="json") %}
+{% set standby = load_data(url="https://gridproxy.grid.tf/stats?status=standby", required=false, format="json") %}
+{% if online and standby %}
+
+  {% set capacity = (online.totalHru + standby.totalHru + online.totalSru + standby.totalSru) / 1024 / 1024 / 1024 / 1024 / 1024 %}
+  {% set nodes = online.nodes + standby.nodes %}
+  {% set countries = online.countries %}
+  {% set cores = online.totalCru + standby.totalCru %}
+  
 {% endif %}
 
-{% if data %}
+{% if online and standby %}
 <div class="lg:py-24 py-10 sm:pt-10">
   <div class="mx-auto px-4 sm:px-6 lg:px-8">
     <div class="lg:max-w-xl mx-auto text-center">

--- a/templates/shortcodes/grid_stats.html
+++ b/templates/shortcodes/grid_stats.html
@@ -1,13 +1,16 @@
 {% set styles = "background-image: url('images/V3.png');" %}
-{% set data = load_data(url="https://gridproxy.grid.tf/stats?status=up", required=false, format="json") %}
-{% if data %}
-{% set capacity = (data.totalHru + data.totalSru) / 1024 / 1024 / 1024 / 1024 / 1024 %}
-{% set nodes = data.nodes %}
-  {% set countries = data.countries %}
-  {% set cores = data.totalCru %}
+{% set online = load_data(url="https://gridproxy.grid.tf/stats?status=up", required=false, format="json") %}
+{% set standby = load_data(url="https://gridproxy.grid.tf/stats?status=standby", required=false, format="json") %}
+{% if online and standby %}
+
+  {% set capacity = (online.totalHru + standby.totalHru + online.totalSru + standby.totalSru) / 1024 / 1024 / 1024 / 1024 / 1024 %}
+  {% set nodes = online.nodes + standby.nodes %}
+  {% set countries = online.countries %}
+  {% set cores = online.totalCru + standby.totalCru %}
+  
 {% endif %}
 
-{% if data %}
+{% if online and standby %}
 <section class="px-2 h-auto bg-center lg:py-28 p-12 bg-cover bg-no-repeat" style="{{styles}}">
     <div class="relative lg:max-w-6xl mx-auto">
         <div class="text-center rounded lg:px-6 mt-10 lg:mt-0 mx-auto">


### PR DESCRIPTION
These days, total grid capacity is a combination of both online nodes and standby nodes. These changes include the standby nodes in the stats presented on the site.

Solves #285.